### PR TITLE
Change process.stdout.cursorTo to readline.cursorTo

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function parseName(nameVersion) {
  * @param  {string[]} args
  * @return {string[]} prompt choices
  */
-function getChoises(command, args) {
+function getChoices(command, args) {
   return [
     `Install (${colors.bold(`${command} ${args.join(' ')}`)})`,
     `Impact`,
@@ -61,7 +61,7 @@ function getChoises(command, args) {
  */
 function promptNextAction(name, versionLoose, packages) {
   return getInstallCommand().then(({ command, args }) => {
-    const choices = getChoises(command, args);
+    const choices = getChoices(command, args);
     return inquirer.prompt({
       type: `list`,
       name: `next`,

--- a/lib/getPackageDetails.js
+++ b/lib/getPackageDetails.js
@@ -8,6 +8,7 @@ const getLicenseStr = require('./getLicenseStr');
 const getLicenseType = require('./getLicenseType');
 const url = require('url');
 const colors = require('colors/safe');
+const readline = require('readline');
 
 const packageDetailsCache = {};
 const registryUrl = `https://registry.npmjs.org/`;
@@ -58,8 +59,8 @@ module.exports = function getPackageDetails(
 ) {
   const versionUrlObj = url.parse(versionLoose);
   if (versionUrlObj.protocol) {
-    process.stdout.cursorTo(0);
-    process.stdout.clearLine(1);
+    readline.cursorTo(process.stdout, 0);
+    readline.clearLine(process.stdout, 1);
     console.error(
       colors.red(`${
         versionUrlObj.protocol.replace(':', '')
@@ -71,8 +72,8 @@ module.exports = function getPackageDetails(
   const key = `${name}@${versionLoose}`;
   const infoUrl = `${registryUrl}${name.replace(`/`, `%2f`)}`;
   if (!packageDetailsCache[key]) {
-    process.stdout.cursorTo(0);
-    process.stdout.clearLine(1);
+    readline.cursorTo(process.stdout, 0);
+    readline.clearLine(process.stdout, 1);
     process.stdout.write(`GET ${infoUrl}`);
     packageDetailsCache[key] = fetch(infoUrl).then(checkResponse).then((packageInfo) => {
       let version;

--- a/lib/install.js
+++ b/lib/install.js
@@ -14,6 +14,7 @@ const formatLicenseType = require('./formatLicenseType');
 const filesize = require('filesize');
 const getSimpleTable = require('./getSimpleTable');
 const program = require('commander');
+const readline = require('readline');
 
 /**
  * indicates if any limits of test config are not satisfied
@@ -121,8 +122,8 @@ function showPackageStats(
   }, packages
 ) {
   const { count, size, licenseTypes } = getPackagesStats(packages);
-  process.stdout.clearLine();
-  process.stdout.cursorTo(0);
+  readline.cursorTo(process.stdout, 0);
+  readline.clearLine(process.stdout);
   const table = getSimpleTable();
   table.push(
     ['Packages', count, '', getLimitResult(

--- a/lib/showDetails.js
+++ b/lib/showDetails.js
@@ -6,6 +6,7 @@ const Table = require('cli-table2');
 const filesize = require('filesize');
 const moment = require('moment');
 const formatLicenseType = require('./formatLicenseType');
+const readline = require('readline');
 
 /**
  * @param  {Object} packages

--- a/lib/showDetails.js
+++ b/lib/showDetails.js
@@ -6,7 +6,6 @@ const Table = require('cli-table2');
 const filesize = require('filesize');
 const moment = require('moment');
 const formatLicenseType = require('./formatLicenseType');
-const readline = require('readline');
 
 /**
  * @param  {Object} packages

--- a/lib/showImpact.js
+++ b/lib/showImpact.js
@@ -10,6 +10,7 @@ const walkDependencies = require('./walkDependencies');
 const getPackagesStats = require('./getPackagesStats');
 const filesize = require('filesize');
 const getSimpleTable = require('./getSimpleTable');
+const readline = require('readline');
 
 /**
  * @param  {Object} impactLicenses  license -> count
@@ -85,8 +86,10 @@ module.exports = function showImpact(
           impactPackagesStats.licenses,
           currentPackagesStats.licenses
         );
-        process.stdout.clearLine();
-        process.stdout.cursorTo(0);
+
+        readline.cursorTo(process.stdout, 0);
+        readline.clearLine(process.stdout);
+
         const table = getSimpleTable();
         table.push([
           'Packages',

--- a/lib/showQuickStats.js
+++ b/lib/showQuickStats.js
@@ -6,14 +6,15 @@ const getPackagesStats = require('./getPackagesStats');
 const formatLicenseType = require('./formatLicenseType');
 const filesize = require('filesize');
 const getSimpleTable = require('./getSimpleTable');
+const readline = require('readline');
 
 /**
  * @param  {Object} packages
  */
 module.exports = function showQuickStats(packages) {
   const { count, size, licenseTypes } = getPackagesStats(packages);
-  process.stdout.clearLine();
-  process.stdout.cursorTo(0);
+  readline.cursorTo(process.stdout, 0);
+  readline.clearLine(process.stdout);
   const table = getSimpleTable();
   table.push(
     ['Packages', count, ''],


### PR DESCRIPTION
process.stdout.cursorTo has been removed in favour of readline.cursorTo in Node 9.
readline.cursorTo has been in the standard library since v4, so should be pretty backward compatible.