### PR TITLE
support for scoped registry urls

### DIFF
--- a/lib/getPackageDetails.js
+++ b/lib/getPackageDetails.js
@@ -11,7 +11,9 @@ const colors = require('colors/safe');
 const readline = require('readline');
 
 const packageDetailsCache = {};
-const registryUrl = `https://registry.npmjs.org/`;
+const npmConfig = require('rc')('npm', {
+	registry: `https://registry.npmjs.org/`
+});
 
 /**
  * @param  {Response} r
@@ -70,6 +72,11 @@ module.exports = function getPackageDetails(
     return Promise.resolve(null);
   }
   const key = `${name}@${versionLoose}`;
+  const scope = (/(@[^\/]+)\/.*/.test(name) && /(@[^\/]+)\/.*/.exec(name)[1]) || ``;
+  var registryUrl = (scope && npmConfig[`${scope}:registry`]) || npmConfig[`registry`];
+  if(registryUrl.charAt(registryUrl.length - 1) !== `/`) {
+	  registryUrl += `/`;
+  }
   const infoUrl = `${registryUrl}${name.replace(`/`, `%2f`)}`;
   if (!packageDetailsCache[key]) {
     readline.cursorTo(process.stdout, 0);

--- a/lib/getPackageDetails.js
+++ b/lib/getPackageDetails.js
@@ -12,7 +12,7 @@ const readline = require('readline');
 
 const packageDetailsCache = {};
 const npmConfig = require('rc')('npm', {
-	registry: `https://registry.npmjs.org/`
+  registry: `https://registry.npmjs.org/`
 });
 
 /**
@@ -72,10 +72,10 @@ module.exports = function getPackageDetails(
     return Promise.resolve(null);
   }
   const key = `${name}@${versionLoose}`;
-  const scope = (/(@[^\/]+)\/.*/.test(name) && /(@[^\/]+)\/.*/.exec(name)[1]) || ``;
-  var registryUrl = (scope && npmConfig[`${scope}:registry`]) || npmConfig[`registry`];
-  if(registryUrl.charAt(registryUrl.length - 1) !== `/`) {
-	  registryUrl += `/`;
+  const scope = name[0] === '@' ? name.slice(0, name.indexOf('/')) : undefined;
+  let registryUrl = (scope && npmConfig[`${scope}:registry`]) || npmConfig.registry;
+  if (registryUrl.charAt(registryUrl.length - 1) !== `/`) {
+    registryUrl += `/`;
   }
   const infoUrl = `${registryUrl}${name.replace(`/`, `%2f`)}`;
   if (!packageDetailsCache[key]) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "promise-queue": "^2.2.3",
     "semver": "^5.4.1",
     "spdx-correct": "^2.0.4",
-    "spdx-satisfies": "^0.1.3"
+    "spdx-satisfies": "^0.1.3",
+    "rc": "^1.2.8"
   }
 }


### PR DESCRIPTION
I got across this when checking one of my projects which contains modules from SAP (@sap/ prefix), those modules are hosted on npm.sap.com. To be able to `npm install` those modules, you need to add this setting to the npm config (for example, to the user config):  

`@sap:registry = "https://npm.sap.com"`

see https://docs.npmjs.com/misc/scope#associating-a-scope-with-a-registry

I was looking for a way to get these npm settings and came across npm-conf, but this module mainly relied on a dependency config-chain to get the configuration. I checked this one and it said:

```
This module is frozen.
In general, I'd recommend using rc instead, but as npm depends on this, it cannot be changed.
```

So I went with rc, which does the job.

rc has the following dependencies:

```
┌───────────────────────────┬─────────┬──────────────┬──────────────────────────────────────────────────┬────────────────────────────┐
│ Package                   │ Size    │ Updated      │ License                                          │ Dependencies               │
├───────────────────────────┼─────────┼──────────────┼────────────┬─────────────────────────────────────┼────────────────────────────┤
│ rc@1.2.8                  │ 6.98 KB │ a month ago  │ Permissive │ (BSD-2-Clause OR MIT OR Apache-2.0) │ deep-extend@^0.6.0,        │
│                           │         │              │            │                                     │ ini@~1.3.0,                │
│                           │         │              │            │                                     │ minimist@^1.2.0,           │
│                           │         │              │            │                                     │ strip-json-comments@~2.0.1 │
├───────────────────────────┼─────────┼──────────────┼────────────┼─────────────────────────────────────┼────────────────────────────┤
│ ini@1.3.5                 │ 3.8 KB  │ 7 months ago │ Permissive │ ISC                                 │                            │
├───────────────────────────┼─────────┼──────────────┼────────────┼─────────────────────────────────────┼────────────────────────────┤
│ minimist@1.2.0            │ 7.54 KB │ 3 years ago  │ Permissive │ MIT                                 │                            │
├───────────────────────────┼─────────┼──────────────┼────────────┼─────────────────────────────────────┼────────────────────────────┤
│ strip-json-comments@2.0.1 │ 2.22 KB │ 2 years ago  │ Permissive │ MIT                                 │                            │
├───────────────────────────┼─────────┼──────────────┼────────────┼─────────────────────────────────────┼────────────────────────────┤
│ deep-extend@0.6.0         │ 3.54 KB │ a month ago  │ Permissive │ MIT                                 │                            │
└───────────────────────────┴─────────┴──────────────┴────────────┴─────────────────────────────────────┴────────────────────────────┘
```

Now rc is used to get the config (global and project specific), the module key is checked for a scope using a regex (starting with @, containing a /). If there is a scope, try to use the registry url of the scope, fallback to the official registry.npmjs.org

npm config is fine when the scoped registry URL does not end with a /, but since we just concaternate the module name, we need to add a / to the url if it doesn't end with one...
