### PR TITLE
feat: implement basic auth for private registry

### DIFF
--- a/lib/getPackageDetails.js
+++ b/lib/getPackageDetails.js
@@ -182,7 +182,7 @@ module.exports = function getPackageDetails(
     readline.clearLine(process.stdout, 1);
     process.stdout.write(`GET ${infoUrl}`);
     const options = {
-      method: "GET"
+      method: 'GET'
     };
 
     if (
@@ -191,7 +191,7 @@ module.exports = function getPackageDetails(
     ) {
       const encoded = Buffer.from(
         `${process.env.PRIVATE_REGISTRY_USER}:${process.env.PRIVATE_REGISTRY_PASSWORD}`
-      ).toString("base64");
+      ).toString('base64');
       options.headers = {
         Authorization: `Basic ${encoded}`
       };

--- a/lib/getPackageDetails.js
+++ b/lib/getPackageDetails.js
@@ -181,7 +181,22 @@ module.exports = function getPackageDetails(
     readline.cursorTo(process.stdout, 0);
     readline.clearLine(process.stdout, 1);
     process.stdout.write(`GET ${infoUrl}`);
-    packageDetailsCache[key] = fetch(infoUrl).then(checkResponse).then((packageInfo) => {
+    const options = {
+      method: "GET"
+    };
+
+    if (
+      process.env.PRIVATE_REGISTRY_USER &&
+      process.env.PRIVATE_REGISTRY_PASSWORD
+    ) {
+      const encoded = Buffer.from(
+        `${process.env.PRIVATE_REGISTRY_USER}:${process.env.PRIVATE_REGISTRY_PASSWORD}`
+      ).toString("base64");
+      options.headers = {
+        Authorization: `Basic ${encoded}`
+      };
+    }
+    packageDetailsCache[key] = fetch(infoUrl, options).then(checkResponse).then((packageInfo) => {
       let version;
       if (!versionLoose) {
         version = packageInfo[`dist-tags`].latest;


### PR DESCRIPTION
Hello,

In my company we use a private registry (Nexus). Our registry is restricted by a basic authentication. 
When we want to execute `npm-consider install --test --production`, the command fails when requesting package details because request is unauthorized. 
So I suggest this feature :
If environment variables `PRIVATE_REGISTRY_USER` and `PRIVATE_REGISTRY_PASSWORD` are provided, then I encode them in base64 and I fill `Authorization` header in order to perform basic authentication.
We have tested it in our environment. 

Is it ok for you ?