### PR TITLE
Treat UNLICENSED as special case for comparisons

### DIFF
--- a/lib/satisfies.js
+++ b/lib/satisfies.js
@@ -4,6 +4,13 @@
 const spdxSatisfies = require('spdx-satisfies');
 const correct = require('spdx-correct');
 
+function correcting(spdx) {
+  if (spdx === 'UNLICENSED') { // See https://github.com/jslicense/spdx-correct.js/issues/3#issuecomment-279799556
+    return spdx;
+  }
+  return correct(spdx);
+}
+
 /**
  * @param  {string} a spdx
  * @param  {string} b spdx
@@ -13,8 +20,8 @@ module.exports = function satisfies(a, b) {
   if (a === b) {
     return true;
   }
-  const ac = correct(a);
-  const bc = correct(b);
+  const ac = correcting(a);
+  const bc = correcting(b);
   if (!ac || !bc) {
     return false;
   }


### PR DESCRIPTION
- Fix: Treat UNLICENSED as special case for comparisons (so it is not confused with "Unlicense")

Fixes #18 .

This issue is due to the fact that `spdx-correct` is not giving special treatment to "UNLICENSED", since it is not a SPDX identifier. As per the package maintainer at https://github.com/jslicense/spdx-correct.js/issues/3#issuecomment-279799556 , consumers need to handle this case (which is indeed a part of *npm* even if not part of SPDX: https://docs.npmjs.com/files/package.json#license ).

(The other special npm case, "SEE LICENSE IN", thankfully doesn't seem to be "corrected" into anything else.)